### PR TITLE
Allow overflowed integers to be converted to decimals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,13 @@ install:
   - ./dockerfile.sh | tee /dev/tty | docker build -t msgpack -
 
 script:
-  - docker run --rm -v $(pwd):/msgpack -w /msgpack -e PHPUNIT_OPTS="$PHPUNIT_OPTS" msgpack
+  - docker run --rm -v $PWD:/msgpack -w /msgpack -e PHPUNIT_OPTS="$PHPUNIT_OPTS" msgpack
   - if [[ -n "$CHECK_CS" ]]; then
-      docker run --rm -v $(pwd):/msgpack -w /msgpack msgpack php vendor/bin/php-cs-fixer fix --dry-run --diff --verbose .;
+      docker run --rm -v $PWD:/msgpack -w /msgpack msgpack php vendor/bin/php-cs-fixer fix --dry-run --diff --verbose .;
     fi
 
 after_script:
   - if [[ -f coverage.clover ]]; then
       curl -sSOL https://scrutinizer-ci.com/ocular.phar &&
-      docker run --rm -v $(pwd):/msgpack -w /msgpack msgpack php ocular.phar code-coverage:upload --format=php-clover coverage.clover;
+      docker run --rm -v $PWD:/msgpack -w /msgpack msgpack php ocular.phar code-coverage:upload --format=php-clover coverage.clover;
     fi

--- a/README.md
+++ b/README.md
@@ -245,16 +245,18 @@ $unpacker->unpackExt();   // PHP MessagePack\Ext class
 The `BufferUnpacker` object supports a number of bitmask-based options for fine-tuning the unpacking process (defaults 
 are in bold):
 
-| Name                 | Description                                                |
-| -------------------- | ---------------------------------------------------------- |
-| **BIGINT_AS_FLOAT**  | Converts overflowed integers to floats <sup>[1]</sup>      |
-| BIGINT_AS_STR        | Converts overflowed integers to strings                    |
-| BIGINT_AS_GMP        | Converts overflowed integers to GMP objects <sup>[2]</sup> |
+| Name              | Description                                                            |
+| ----------------- | ---------------------------------------------------------------------- |
+| **BIGINT_AS_STR** | Converts overflowed integers to strings <sup>[1]</sup>                 |
+| BIGINT_AS_GMP     | Converts overflowed integers to GMP objects <sup>[2]</sup>             |
+| BIGINT_AS_DEC     | Converts overflowed integers to Decimal\Decimal objects <sup>[3]</sup> |
 
 > *1. The binary MessagePack format has unsigned 64-bit as its largest integer data type,
 >    but PHP does not support such integers, which means that an overflow can occur during unpacking.*
 >
 > *2. Make sure the [GMP](http://php.net/manual/en/book.gmp.php) extension is enabled.*
+>
+> *3. Make sure the [Decimal](http://php-decimal.io/) extension is enabled.*
 
 
 Examples:
@@ -266,13 +268,13 @@ use MessagePack\UnpackOptions;
 $packedUint64 = "\xcf"."\xff\xff\xff\xff"."\xff\xff\xff\xff";
 
 $unpacker = new BufferUnpacker($packedUint64);
-var_dump($unpacker->unpack()); // double(1.844674407371E+19)
-
-$unpacker = new BufferUnpacker($packedUint64, UnpackOptions::BIGINT_AS_STR);
 var_dump($unpacker->unpack()); // string(20) "18446744073709551615"
 
 $unpacker = new BufferUnpacker($packedUint64, UnpackOptions::BIGINT_AS_GMP);
 var_dump($unpacker->unpack()); // object(GMP) {...}
+
+$unpacker = new BufferUnpacker($packedUint64, UnpackOptions::BIGINT_AS_DEC);
+var_dump($unpacker->unpack()); // object(Decimal\Decimal) {...}
 ```
 
 
@@ -446,7 +448,7 @@ PHP_RUNTIME='php:7.3-cli' ./dockerfile.sh | docker build -t msgpack -
 Then run the unit tests:
 
 ```sh
-docker run --rm --name msgpack -v $(pwd):/msgpack -w /msgpack msgpack
+docker run --rm --name msgpack -v $PWD:/msgpack -w /msgpack msgpack
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ PHP_RUNTIME='php:7.3-cli' ./dockerfile.sh | docker build -t msgpack -
 Then run the unit tests:
 
 ```sh
-docker run --rm --name msgpack -v $PWD:/msgpack -w /msgpack msgpack
+docker run --rm -v $PWD:/msgpack -w /msgpack msgpack
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -112,18 +112,18 @@ $packer->packExt(1, "\xaa");  // MP ext
 The `Packer` object supports a number of bitmask-based options for fine-tuning the packing 
 process (defaults are in bold):
 
-| Name               | Description                                                   |
-| ------------------ | ------------------------------------------------------------- |
-| FORCE_STR          | Forces PHP strings to be packed as MessagePack UTF-8 strings  |
-| FORCE_BIN          | Forces PHP strings to be packed as MessagePack binary data    |
-| **DETECT_STR_BIN** | Detects MessagePack str/bin type automatically                |
-|                    |                                                               |
-| FORCE_ARR          | Forces PHP arrays to be packed as MessagePack arrays          |
-| FORCE_MAP          | Forces PHP arrays to be packed as MessagePack maps            |
-| **DETECT_ARR_MAP** | Detects MessagePack array/map type automatically              |
-|                    |                                                               |
-| FORCE_FLOAT32      | Forces PHP floats to be packed as 32-bits MessagePack floats  |
-| **FORCE_FLOAT64**  | Forces PHP floats to be packed as 64-bits MessagePack floats  |
+| Name                 | Description                                                   |
+| -------------------- | ------------------------------------------------------------- |
+| `FORCE_STR`          | Forces PHP strings to be packed as MessagePack UTF-8 strings  |
+| `FORCE_BIN`          | Forces PHP strings to be packed as MessagePack binary data    |
+| **`DETECT_STR_BIN`** | Detects MessagePack str/bin type automatically                |
+|                      |                                                               |
+| `FORCE_ARR`          | Forces PHP arrays to be packed as MessagePack arrays          |
+| `FORCE_MAP`          | Forces PHP arrays to be packed as MessagePack maps            |
+| **`DETECT_ARR_MAP`** | Detects MessagePack array/map type automatically              |
+|                      |                                                               |
+| `FORCE_FLOAT32`      | Forces PHP floats to be packed as 32-bits MessagePack floats  |
+| **`FORCE_FLOAT64`**  | Forces PHP floats to be packed as 64-bits MessagePack floats  |
 
 > *The type detection mode (`DETECT_STR_BIN`/`DETECT_ARR_MAP`) adds some overhead which can be noticed when you pack 
 > large (16- and 32-bit) arrays or strings. However, if you know the value type in advance (for example, you only 
@@ -245,11 +245,11 @@ $unpacker->unpackExt();   // PHP MessagePack\Ext class
 The `BufferUnpacker` object supports a number of bitmask-based options for fine-tuning the unpacking process (defaults 
 are in bold):
 
-| Name              | Description                                                            |
-| ----------------- | ---------------------------------------------------------------------- |
-| **BIGINT_AS_STR** | Converts overflowed integers to strings <sup>[1]</sup>                 |
-| BIGINT_AS_GMP     | Converts overflowed integers to GMP objects <sup>[2]</sup>             |
-| BIGINT_AS_DEC     | Converts overflowed integers to Decimal\Decimal objects <sup>[3]</sup> |
+| Name                | Description                                                              |
+| ------------------- | ------------------------------------------------------------------------ |
+| **`BIGINT_AS_STR`** | Converts overflowed integers to strings <sup>[1]</sup>                   |
+| `BIGINT_AS_GMP`     | Converts overflowed integers to `GMP` objects <sup>[2]</sup>             |
+| `BIGINT_AS_DEC`     | Converts overflowed integers to `Decimal\Decimal` objects <sup>[3]</sup> |
 
 > *1. The binary MessagePack format has unsigned 64-bit as its largest integer data type,
 >    but PHP does not support such integers, which means that an overflow can occur during unpacking.*

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,14 @@
         "php": "^7.1.1"
     },
     "require-dev": {
+        "ext-decimal": "*",
+        "ext-gmp": '*',
         "friendsofphp/php-cs-fixer": "^2.14",
         "phpunit/phpunit": "^7.1|^8.0"
+    },
+    "suggest": {
+        "ext-decimal": "For converting overflowed integers to Decimal\Decimal objects",
+        "ext-gmp": "For converting overflowed integers to GMP objects"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,12 @@
     },
     "require-dev": {
         "ext-decimal": "*",
-        "ext-gmp": '*',
+        "ext-gmp": "*",
         "friendsofphp/php-cs-fixer": "^2.14",
         "phpunit/phpunit": "^7.1|^8.0"
     },
     "suggest": {
-        "ext-decimal": "For converting overflowed integers to Decimal\Decimal objects",
+        "ext-decimal": "For converting overflowed integers to Decimal objects",
         "ext-gmp": "For converting overflowed integers to GMP objects"
     },
     "autoload": {

--- a/dockerfile.sh
+++ b/dockerfile.sh
@@ -5,6 +5,9 @@ if [[ -z "$PHP_RUNTIME" ]]; then
 fi
 
 RUN_CMDS=''
+RUN_CMDS="$RUN_CMDS && \\\\\n    apt-get install -y libmpdec-dev"
+RUN_CMDS="$RUN_CMDS && \\\\\n    pecl install decimal && docker-php-ext-enable decimal"
+
 if [[ $PHPUNIT_OPTS =~ (^|[[:space:]])--coverage-[[:alpha:]] ]]; then
     RUN_CMDS="$RUN_CMDS && \\\\\n    pecl install pcov && docker-php-ext-enable pcov"
 fi

--- a/src/BufferUnpacker.php
+++ b/src/BufferUnpacker.php
@@ -11,6 +11,7 @@
 
 namespace MessagePack;
 
+use Decimal\Decimal;
 use MessagePack\Exception\InsufficientDataException;
 use MessagePack\Exception\InvalidOptionException;
 use MessagePack\Exception\UnpackingFailedException;
@@ -20,7 +21,7 @@ class BufferUnpacker
 {
     private $buffer;
     private $offset = 0;
-    private $isBigIntAsStr;
+    private $isBigIntAsDec;
     private $isBigIntAsGmp;
 
     /**
@@ -42,7 +43,7 @@ class BufferUnpacker
             $options = UnpackOptions::fromBitmask($options);
         }
 
-        $this->isBigIntAsStr = $options->isBigIntAsStrMode();
+        $this->isBigIntAsDec = $options->isBigIntAsDecMode();
         $this->isBigIntAsGmp = $options->isBigIntAsGmpMode();
 
         $this->buffer = $buffer;
@@ -557,14 +558,14 @@ class BufferUnpacker
         if ($num >= 0) {
             return $num;
         }
-        if ($this->isBigIntAsStr) {
-            return \sprintf('%u', $num);
+        if ($this->isBigIntAsDec) {
+            return new Decimal(\sprintf('%u', $num));
         }
         if ($this->isBigIntAsGmp) {
             return \gmp_init(\sprintf('%u', $num));
         }
 
-        return (float) \sprintf('%u', $num);
+        return \sprintf('%u', $num);
     }
 
     private function unpackInt8()

--- a/src/UnpackOptions.php
+++ b/src/UnpackOptions.php
@@ -15,9 +15,9 @@ use MessagePack\Exception\InvalidOptionException;
 
 final class UnpackOptions
 {
-    public const BIGINT_AS_FLOAT = 0b001;
-    public const BIGINT_AS_STR   = 0b010;
-    public const BIGINT_AS_GMP   = 0b100;
+    public const BIGINT_AS_STR = 0b001;
+    public const BIGINT_AS_GMP = 0b010;
+    public const BIGINT_AS_DEC = 0b100;
 
     private $bigIntMode;
 
@@ -28,7 +28,7 @@ final class UnpackOptions
     public static function fromDefaults() : self
     {
         $self = new self();
-        $self->bigIntMode = self::BIGINT_AS_FLOAT;
+        $self->bigIntMode = self::BIGINT_AS_STR;
 
         return $self;
     }
@@ -38,17 +38,12 @@ final class UnpackOptions
         $self = new self();
 
         $self->bigIntMode = self::getSingleOption('bigint', $bitmask,
-            self::BIGINT_AS_FLOAT |
             self::BIGINT_AS_STR |
-            self::BIGINT_AS_GMP
-        ) ?: self::BIGINT_AS_FLOAT;
+            self::BIGINT_AS_GMP |
+            self::BIGINT_AS_DEC
+        ) ?: self::BIGINT_AS_STR;
 
         return $self;
-    }
-
-    public function isBigIntAsFloatMode() : bool
-    {
-        return self::BIGINT_AS_FLOAT === $this->bigIntMode;
     }
 
     public function isBigIntAsStrMode() : bool
@@ -61,6 +56,11 @@ final class UnpackOptions
         return self::BIGINT_AS_GMP === $this->bigIntMode;
     }
 
+    public function isBigIntAsDecMode() : bool
+    {
+        return self::BIGINT_AS_DEC === $this->bigIntMode;
+    }
+
     private static function getSingleOption(string $name, int $bitmask, int $validBitmask) : int
     {
         $option = $bitmask & $validBitmask;
@@ -69,9 +69,9 @@ final class UnpackOptions
         }
 
         static $map = [
-            self::BIGINT_AS_FLOAT => 'BIGINT_AS_FLOAT',
             self::BIGINT_AS_STR => 'BIGINT_AS_STR',
             self::BIGINT_AS_GMP => 'BIGINT_AS_GMP',
+            self::BIGINT_AS_DEC => 'BIGINT_AS_DEC',
         ];
 
         $validOptions = [];

--- a/tests/Unit/BufferUnpackerTest.php
+++ b/tests/Unit/BufferUnpackerTest.php
@@ -11,6 +11,7 @@
 
 namespace MessagePack\Tests\Unit;
 
+use Decimal\Decimal;
 use MessagePack\BufferUnpacker;
 use MessagePack\Exception\InsufficientDataException;
 use MessagePack\Exception\InvalidOptionException;
@@ -112,24 +113,14 @@ final class BufferUnpackerTest extends TestCase
         $this->unpacker->unpack();
     }
 
-    public function testUnpackBigIntDefaultModeFloat() : void
+    public function testUnpackBigIntDefaultMode() : void
     {
         $unpacker = new BufferUnpacker("\xcf"."\xff\xff\xff\xff"."\xff\xff\xff\xff");
 
-        self::assertSame('1.8446744073709552E+19', var_export($unpacker->unpack(), true));
+        self::assertSame('18446744073709551615', $unpacker->unpack());
     }
 
-    public function testUnpackBigIntAsFloat() : void
-    {
-        $unpacker = new BufferUnpacker(
-            "\xcf"."\xff\xff\xff\xff"."\xff\xff\xff\xff",
-            UnpackOptions::BIGINT_AS_FLOAT
-        );
-
-        self::assertSame('1.8446744073709552E+19', var_export($unpacker->unpack(), true));
-    }
-
-    public function testUnpackBigIntAsString() : void
+    public function testUnpackBigIntAsStr() : void
     {
         $unpacker = new BufferUnpacker(
             "\xcf"."\xff\xff\xff\xff"."\xff\xff\xff\xff",
@@ -153,6 +144,22 @@ final class BufferUnpackerTest extends TestCase
 
         self::assertInstanceOf(\GMP::class, $uint64);
         self::assertSame('18446744073709551615', gmp_strval($uint64));
+    }
+
+    /**
+     * @requires extension decimal
+     */
+    public function testUnpackBigIntAsDec() : void
+    {
+        $unpacker = new BufferUnpacker(
+            "\xcf"."\xff\xff\xff\xff"."\xff\xff\xff\xff",
+            UnpackOptions::BIGINT_AS_DEC
+        );
+
+        $uint64 = $unpacker->unpack();
+
+        self::assertInstanceOf(Decimal::class, $uint64);
+        self::assertSame('18446744073709551615', $uint64->toString());
     }
 
     public function testResetEmptiesBuffer() : void
@@ -339,9 +346,9 @@ final class BufferUnpackerTest extends TestCase
     {
         return [
             [UnpackOptions::BIGINT_AS_STR | UnpackOptions::BIGINT_AS_GMP],
-            [UnpackOptions::BIGINT_AS_STR | UnpackOptions::BIGINT_AS_FLOAT],
-            [UnpackOptions::BIGINT_AS_GMP | UnpackOptions::BIGINT_AS_FLOAT],
-            [UnpackOptions::BIGINT_AS_STR | UnpackOptions::BIGINT_AS_GMP | UnpackOptions::BIGINT_AS_FLOAT],
+            [UnpackOptions::BIGINT_AS_STR | UnpackOptions::BIGINT_AS_DEC],
+            [UnpackOptions::BIGINT_AS_GMP | UnpackOptions::BIGINT_AS_DEC],
+            [UnpackOptions::BIGINT_AS_STR | UnpackOptions::BIGINT_AS_GMP | UnpackOptions::BIGINT_AS_DEC],
         ];
     }
 

--- a/tests/Unit/UnpackOptionsTest.php
+++ b/tests/Unit/UnpackOptionsTest.php
@@ -30,20 +30,20 @@ final class UnpackOptionsTest extends TestCase
     public function provideIsserData() : array
     {
         return [
-            ['isBigIntAsFloatMode', true, 0],
-            ['isBigIntAsFloatMode', false, UnpackOptions::BIGINT_AS_STR],
-            ['isBigIntAsFloatMode', false, UnpackOptions::BIGINT_AS_GMP],
-            ['isBigIntAsFloatMode', true, UnpackOptions::BIGINT_AS_FLOAT],
-
-            ['isBigIntAsStrMode', false, 0],
+            ['isBigIntAsStrMode', true, 0],
             ['isBigIntAsStrMode', true, UnpackOptions::BIGINT_AS_STR],
             ['isBigIntAsStrMode', false, UnpackOptions::BIGINT_AS_GMP],
-            ['isBigIntAsStrMode', false, UnpackOptions::BIGINT_AS_FLOAT],
+            ['isBigIntAsStrMode', false, UnpackOptions::BIGINT_AS_DEC],
 
             ['isBigIntAsGmpMode', false, 0],
             ['isBigIntAsGmpMode', false, UnpackOptions::BIGINT_AS_STR],
             ['isBigIntAsGmpMode', true, UnpackOptions::BIGINT_AS_GMP],
-            ['isBigIntAsGmpMode', false, UnpackOptions::BIGINT_AS_FLOAT],
+            ['isBigIntAsGmpMode', false, UnpackOptions::BIGINT_AS_DEC],
+
+            ['isBigIntAsDecMode', false, 0],
+            ['isBigIntAsDecMode', false, UnpackOptions::BIGINT_AS_STR],
+            ['isBigIntAsDecMode', false, UnpackOptions::BIGINT_AS_GMP],
+            ['isBigIntAsDecMode', true, UnpackOptions::BIGINT_AS_DEC],
         ];
     }
 
@@ -67,7 +67,7 @@ final class UnpackOptionsTest extends TestCase
     {
         yield [
             UnpackOptions::BIGINT_AS_GMP | UnpackOptions::BIGINT_AS_STR,
-            'Invalid option bigint, use one of MessagePack\UnpackOptions::BIGINT_AS_FLOAT, MessagePack\UnpackOptions::BIGINT_AS_STR or MessagePack\UnpackOptions::BIGINT_AS_GMP.',
+            'Invalid option bigint, use one of MessagePack\UnpackOptions::BIGINT_AS_STR, MessagePack\UnpackOptions::BIGINT_AS_GMP or MessagePack\UnpackOptions::BIGINT_AS_DEC.',
         ];
     }
 }


### PR DESCRIPTION
Also, drop `UnpackOptions::BIGINT_AS_FLOAT`.