### PR TITLE
Mask chr input to prevent deprecation warnings on PHP 8.5

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -23,6 +23,7 @@ jobs:
           - PHP_IMAGE: php:8.2-cli
           - PHP_IMAGE: php:8.3-cli
           - PHP_IMAGE: php:8.4-cli
+          - PHP_IMAGE: php:8.5-cli
 
     runs-on: ${{ matrix.operating-system }}
     steps:

--- a/src/Packer.php
+++ b/src/Packer.php
@@ -177,7 +177,7 @@ class Packer
                 return "\xcc".\chr($int);
             }
             if ($int <= 0xffff) {
-                return "\xcd".\chr($int >> 8).\chr($int);
+                return "\xcd".\chr($int >> 8).\chr($int & 0xff);
             }
             if ($int <= 0xffffffff) {
                 return \pack('CN', 0xce, $int);
@@ -190,10 +190,10 @@ class Packer
             return \chr(0xe0 | $int);
         }
         if ($int >= -0x80) {
-            return "\xd0".\chr($int);
+            return "\xd0".\chr($int & 0xff);
         }
         if ($int >= -0x8000) {
-            return "\xd1".\chr($int >> 8).\chr($int);
+            return "\xd1".\chr($int >> 8 & 0xff).\chr($int & 0xff);
         }
         if ($int >= -0x80000000) {
             return \pack('CN', 0xd2, $int);
@@ -250,7 +250,7 @@ class Packer
             return "\xd9".\chr($length).$str;
         }
         if ($length <= 0xffff) {
-            return "\xda".\chr($length >> 8).\chr($length).$str;
+            return "\xda".\chr($length >> 8).\chr($length & 0xff).$str;
         }
 
         return \pack('CN', 0xdb, $length).$str;
@@ -269,7 +269,7 @@ class Packer
             return "\xc4".\chr($length).$str;
         }
         if ($length <= 0xffff) {
-            return "\xc5".\chr($length >> 8).\chr($length).$str;
+            return "\xc5".\chr($length >> 8).\chr($length & 0xff).$str;
         }
 
         return \pack('CN', 0xc6, $length).$str;
@@ -302,7 +302,7 @@ class Packer
             return \chr(0x90 | $size);
         }
         if ($size <= 0xffff) {
-            return "\xdc".\chr($size >> 8).\chr($size);
+            return "\xdc".\chr($size >> 8).\chr($size & 0xff);
         }
 
         return \pack('CN', 0xdd, $size);
@@ -356,7 +356,7 @@ class Packer
             return \chr(0x80 | $size);
         }
         if ($size <= 0xffff) {
-            return "\xde".\chr($size >> 8).\chr($size);
+            return "\xde".\chr($size >> 8).\chr($size & 0xff);
         }
 
         return \pack('CN', 0xdf, $size);

--- a/src/Packer.php
+++ b/src/Packer.php
@@ -187,7 +187,7 @@ class Packer
         }
 
         if ($int >= -0x20) {
-            return \chr(0xe0 | $int);
+            return \chr(0xe0 | $int & 0xff);
         }
         if ($int >= -0x80) {
             return "\xd0".\chr($int & 0xff);
@@ -373,15 +373,15 @@ class Packer
         $length = \strlen($data);
 
         switch ($length) {
-            case 1: return "\xd4".\chr($type).$data;
-            case 2: return "\xd5".\chr($type).$data;
-            case 4: return "\xd6".\chr($type).$data;
-            case 8: return "\xd7".\chr($type).$data;
-            case 16: return "\xd8".\chr($type).$data;
+            case 1: return "\xd4".\chr($type & 0xff).$data;
+            case 2: return "\xd5".\chr($type & 0xff).$data;
+            case 4: return "\xd6".\chr($type & 0xff).$data;
+            case 8: return "\xd7".\chr($type & 0xff).$data;
+            case 16: return "\xd8".\chr($type & 0xff).$data;
         }
 
         if ($length <= 0xff) {
-            return "\xc7".\chr($length).\chr($type).$data;
+            return "\xc7".\chr($length).\chr($type & 0xff).$data;
         }
         if ($length <= 0xffff) {
             return \pack('CnC', 0xc8, $length, $type).$data;


### PR DESCRIPTION
Prevents deprecation warnings in PHP 8.5

    Deprecated: chr(): Providing a value not in-between 0 and 255 is deprecated, this is because a byte value must be in the [0, 255] interval. The value used will be constrained using % 256